### PR TITLE
Add Japanese docs for prompt and flow

### DIFF
--- a/flow.ja.md
+++ b/flow.ja.md
@@ -1,0 +1,74 @@
+# Gemini CLI ドキュメントの流れ
+
+このドキュメントでは、リポジトリ内の主要なドキュメントページ（`prompt.md` を除く）の構成と、それぞれの要点を簡潔にまとめています。
+
+## リポジトリ概要
+
+- **README.md** – Gemini CLI の紹介、機能（コード検索、生成、自動化）と、Node または Homebrew でのインストール方法のクイックスタートを掲載。認証方法（Google ログイン、Gemini API キー、Vertex AI キー）を説明し、トラブルシューティングへのリンクやよく使われるタスクを記載しています。
+- **ROADMAP.md** – 指針となる原則や、GitHub Issues を通じた開発の進め方を説明。重点分野（Authentication、Model、User Experience、Tooling、Core、Extensibility、Contribution、Platform、Quality、Background Agents、Security & Privacy）を挙げ、コミュニティ参加を呼びかけています。
+- **CONTRIBUTING.md** – コントリビューターライセンス契約、レビュー手順、PR ガイドライン、`npm run preflight` 実行方法などを詳細に記述しています。
+
+## `docs/` ディレクトリ
+
+### index.md
+ドキュメントの入り口となるページで、実行・デプロイ、アーキテクチャ、CLI 使い方、コアの詳細、ツール、コントリビュートガイド、NPM ワークフロー、トラブルシューティング、利用規約とプライバシーへのリンクを掲載しています。
+
+### architecture.md
+二つのパッケージ構成を説明しています：
+1. **CLI パッケージ (`packages/cli`)** – 入力、履歴、表示、テーマ、設定を管理。
+2. **Core パッケージ (`packages/core`)** – Gemini API との通信、プロンプト生成、ツール実行、会話状態を管理。
+3. **Tools** – ファイルシステムやシェルコマンド、Web 取得/検索など機能を拡張します。
+ドキュメントでは典型的な対話フローと、モジュール性・拡張性・ユーザー体験といった設計原則を解説しています。
+
+### deployment.md
+Gemini CLI の実行方法を説明：
+- 一般的な npm インストールまたは npx の利用。
+- Docker/Podman サンドボックス実行（`--sandbox` フラグ）。
+- コントリビューター向けのソースからの実行。
+- GitHub から最新コミットを実行。
+ビルドプロセスやサンドボックス用コンテナイメージ、リリースの自動化についても触れています。
+
+### Uninstall.md
+npx キャッシュを削除する方法や `npm uninstall -g @google/gemini-cli` を使ったアンインストール方法など、インストール形態別に削除手順を案内します。
+
+### troubleshooting.md
+認証の問題、ツール不足、CI 検出、パーミッションエラーといったよくあるトラブルの解決策を提供し、`--verbose` の利用やログ確認などデバッグのヒントを掲載しています。
+
+### quota-and-pricing.md
+Google ログイン（Code Assist ティア）、Gemini API キー（無料/有料）、Vertex AI オプションごとのレート制限と料金をまとめています。Google One/Ultra プランは現在ウェブ製品のみ対象である点も記載。
+
+### tos-privacy.md
+各認証方法における利用規約とプライバシー通知をまとめ、データ収集や使用統計のオプトアウトに関する FAQ を掲載しています。
+
+### sandbox.md
+macOS seatbelt や Docker/Podman を用いたサンドボックス方式、設定フラグや環境変数、トラブルシューティング、セキュリティに関する注意点を説明します。
+
+### checkpointing.md
+ツールがファイルを変更する前にプロジェクト状態と会話履歴をスナップショットとして保存するチェックポイント機能を解説。フラグや設定での有効化方法、`/restore` による復元方法を紹介します。
+
+### extension.md
+`.gemini/extensions` ディレクトリから拡張機能を読み込む仕組みを説明。各拡張には MCP サーバーやコンテキストファイル、ツール制限を指定する `gemini-extension.json` を含みます。ワークスペースの拡張がユーザーの拡張より優先されます。
+
+### telemetry.md
+OpenTelemetry によるテレメトリを扱います。フラグ、環境変数、設定の優先順位、ファイルや Google Cloud へのエクスポート方法、記録されるイベントやメトリクスを解説します。
+
+### npm.md
+公開されている二つのパッケージ（`@google/gemini-cli` と `@google/gemini-cli-core`）の説明と、リリースのバンドル・自動化方法を説明します。
+
+### integration-tests.md
+`integration-tests/` 以下の end-to-end テストフレームワークを紹介。すべてのテストや個別テストの実行、サンドボックスマトリクスの利用、デバッグ用出力保持、詳細ログ実行、GitHub Actions でのテスト実行を説明します。
+
+### examples, tools, core, cli サブディレクトリ
+- **core/index.md と tools-api.md** – Core パッケージの役割や、ツールの定義・登録・実行方法を要約。ファイルシステムリーダー、シェル実行、Web 取得/検索、メモリツールなどの組み込みツールや、コマンドや MCP サーバー経由でのカスタムツール発見方法を紹介します。
+- **core/memport.md** – `@file.md` インポート構文によるモジュール化された `GEMINI.md` の記法、安全機能、使用例を解説します。
+- **cli/index.md** – CLI フロントエンドの概要を提供。非対話モード、認証、コマンド、設定、トークンキャッシュ、テーマ、チュートリアルへのリンクを記載します。
+- **cli/commands.md** – スラッシュコマンド（`/bug`、`/chat`、`/clear`、`/compress`、`/copy`、`/memory`、`/restore`、`/stats`、`/theme` など）の詳細リファレンス、`@` コマンドでのファイル内容挿入、`!` シェルコマンド、TOML でのカスタムコマンド作成方法を網羅します。
+- **cli/configuration.md** – `contextFileName` やツールの許可/除外リスト、MCP サーバー設定、自動承認、テーマ、vim モード、サンドボックス設定、チェックポイント、テレメトリ、使用統計、`.env` ファイルから読み込む環境変数など、設定レイヤーと全オプションを説明します。
+- **cli/authentication.md** – Google でのログイン、Gemini API キー、Vertex AI キー、Cloud Shell 認証の方法を案内。`.env` ファイルによる環境変数保持や非対話モードでの利用も説明します。
+- **cli/themes.md** – 組み込みのダーク/ライトテーマの一覧、テーマ変更方法、`settings.json` でのカスタムテーマ作成方法を説明します。
+- **cli/token-caching.md** – API キー使用時のトークンキャッシュと、`/stats` での節約トークン表示方法を説明します。
+- **cli/tutorials.md** – `mcpServers` 設定を用いて、GitHub MCP サーバーを例にモデルコンテキストプロトコル (MCP) サーバーを設定する手順を説明します。
+- **tools/** – ファイルシステム、複数ファイル読み込み、シェル、Web 取得/検索、メモリ、MCP サーバー実行など、組み込みツールの詳細を提供します。
+
+## まとめ
+Gemini CLI のドキュメントは、インストール、設定、コマンドリファレンス、ツールの利用、アーキテクチャ、開発ガイドラインを網羅しています。`README.md` と `docs/index.md` がユーザーを各ガイド（認証、コマンド、設定、ツール、トラブルシューティング、テレメトリなど）へ導きます。Core と CLI パッケージは個別に説明され、多数の例を通じて効率的な利用と拡張方法を学べます。

--- a/prompt.ja.md
+++ b/prompt.ja.md
@@ -1,0 +1,65 @@
+# LLMプロンプトの概要
+
+このプロジェクトでは、LLMに送信される複数のプロンプトを定義しています。以下は各プロンプトの概要と利用方法です。
+
+## 1. コアシステムプロンプト
+- **場所:** `packages/core/src/core/prompts.ts` (`getCoreSystemPrompt`)
+- **目的:** すべてのチャットセッションで使用される基本指示。ユーザーとの対話方法やツールの利用規則を示します。
+- **抜粋:**
+```
+You are an interactive CLI agent specializing in software engineering tasks...
+```
+- **使用タイミング:** 新しい`GeminiChat`インスタンスを初期化する際に送信されます。
+
+## 2. 圧縮プロンプト
+- **場所:** `packages/core/src/core/prompts.ts` (`getCompressionPrompt`)
+- **目的:** 長いチャット履歴をメモリ用のXMLスナップショットへ要約します。
+- **抜粋:**
+```
+You are the component that summarizes internal chat history into a given structure...
+```
+- **使用タイミング:** 履歴が制限を超えた際に `GeminiClient.tryCompressChat` から呼び出されます。
+
+## 3. ツール出力要約プロンプト
+- **場所:** `packages/core/src/utils/summarizer.ts`
+- **目的:** ツールの出力が長すぎる場合に、ユーザーへ返す前に要約します。
+- **抜粋:**
+```
+Summarize the following tool output to be a maximum of {maxOutputTokens} tokens...
+```
+- **使用タイミング:** `llmSummarizer` がさまざまなツールで大きな出力を処理する際に使用します。
+
+## 4. ループ検出プロンプト
+- **場所:** `packages/core/src/services/loopDetectionService.ts`
+- **目的:** アシスタントが同じ内容を繰り返しているかを検出します。
+- **抜粋:**
+```
+You are a sophisticated AI diagnostic agent specializing in identifying when a conversational AI is stuck...
+```
+- **使用タイミング:** セッション中に `LoopDetectionService.checkForLoopWithLLM` が定期的に呼び出します。
+
+## 5. 次の話者判定プロンプト
+- **場所:** `packages/core/src/utils/nextSpeakerChecker.ts`
+- **目的:** 次にユーザーとモデルのどちらが発言すべきかを判断します。
+- **抜粋:**
+```
+Analyze *only* the content and structure of your immediately preceding response...
+```
+- **使用タイミング:** モデルの応答後に `checkNextSpeaker` が会話を続けるかどうか判断するために呼び出します。
+
+## 6. 編集補正プロンプト
+`packages/core/src/utils/editCorrector.ts` で定義され、ファイルを変更する前にテキスト置換を調整するために使われます。
+
+- **旧文字列不一致プロンプト** – 置換対象のテキストが過剰にエスケープされている場合、正しい箇所を見つけるのを補助します。
+- **新文字列調整プロンプト** – 修正した旧文字列に合わせて新しいテキストを調整します。
+- **新文字列エスケーププロンプト** – 新しいテキストのエスケープを修正します。
+- **汎用文字列エスケーププロンプト** – 任意の文字列のエスケープ問題を修正します。
+
+これらのプロンプトは、編集を適用する前に `geminiClient.generateJson` を介して送信されます。
+
+## プロンプトの流れ
+1. **セッション開始:** `GeminiClient.getChat()` が **コアシステムプロンプト** を送信します。
+2. **ユーザー/モデルのやり取り:** メッセージを交換し、ツールが大量の出力を生成した場合は **ツール出力要約プロンプト** がトリガーされます。
+3. **ループ・話者チェック:** セッション中に `LoopDetectionService` と `NextSpeakerChecker` がプロンプトを実行し、会話を円滑に進めるか次に誰が話すべきかを判断します。
+4. **履歴の圧縮:** 履歴が大きくなりすぎたら、`getCompressionPrompt` を使ってスナップショットにまとめます。
+5. **編集作業:** テキスト置換を行う際、各種 **編集補正プロンプト** を利用して旧・新文字列を整えます。


### PR DESCRIPTION
## Summary
- add `prompt.ja.md` Japanese translation of prompt overview
- add `flow.ja.md` Japanese translation of documentation flow

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68880172d4308323a9518591244c509b