### PR TITLE
Add Japanese comments

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// このファイルはCLIツールのエントリーポイントです
 
 /**
  * @license
@@ -9,9 +10,11 @@
 import './src/gemini.js';
 import { main } from './src/gemini.js';
 
+// main関数を呼び出してGemini CLIを実行する
+
 // --- Global Entry Point ---
 main().catch((error) => {
-  console.error('An unexpected critical error occurred:');
+  console.error('An unexpected critical error occurred:'); // 予期しない致命的なエラー
   if (error instanceof Error) {
     console.error(error.stack);
   } else {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -2,7 +2,9 @@
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
- */
+*/
+
+// Gemini CLI のメインロジックを提供するモジュール
 
 import React from 'react';
 import { render } from 'ink';
@@ -41,6 +43,8 @@ import { validateAuthMethod } from './config/auth.js';
 import { setMaxSizedBoxDebugging } from './ui/components/shared/MaxSizedBox.js';
 import { validateNonInteractiveAuth } from './validateNonInterActiveAuth.js';
 import { appEvents, AppEvent } from './utils/events.js';
+
+// Node.jsが使用できるメモリ量を計算して必要なら再起動オプションを返す
 
 function getNodeMemoryArgs(config: Config): string[] {
   const totalMemoryMB = os.totalmem() / (1024 * 1024);
@@ -87,6 +91,8 @@ async function relaunchWithAdditionalArgs(additionalArgs: string[]) {
 }
 import { runAcpPeer } from './acp/acpPeer.js';
 
+// 未処理のPromise拒否を捕捉してユーザーに通知する
+
 export function setupUnhandledRejectionHandler() {
   let unhandledRejectionOccurred = false;
   process.on('unhandledRejection', (reason, _promise) => {
@@ -109,6 +115,7 @@ ${reason.stack}`
   });
 }
 
+// CLIアプリケーションのメイン処理を開始する
 export async function main() {
   setupUnhandledRejectionHandler();
   const workspaceRoot = process.cwd();

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// コアモジュールの公開APIをまとめたエントリーファイル
+
 export * from './src/index.js';
+
+// デフォルトモデルの定義を再公開する
 export {
   DEFAULT_GEMINI_MODEL,
   DEFAULT_GEMINI_FLASH_MODEL,

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -2,7 +2,10 @@
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
- */
+*/
+
+// 認証方式に応じて Gemini API へのリクエストを生成するラッパー。
+// モデルの選択やプロキシ設定を行い、各種生成・埋め込み API を呼び出す。
 
 import {
   CountTokensResponse,

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -2,7 +2,10 @@
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
- */
+*/
+
+// Gemini API と対話し、履歴管理やストリーム処理を行うチャットセッション。
+// エージェントが生成するメッセージを送り、応答を受け取って履歴に記録する。
 
 // DISCLAIMER: This is a copied version of https://github.com/googleapis/js-genai/blob/main/src/chats.ts with the intention of working around a key bug
 // where function responses are not treated as "valid" responses: https://b.corp.google.com/issues/420354090

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -2,7 +2,11 @@
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
- */
+*/
+
+// このファイルではエージェントの基盤となるシステムプロンプトを生成する。
+// 環境変数 `GEMINI_SYSTEM_MD` を使うと外部ファイルからプロンプトを上書きでき、
+// `GEMINI_WRITE_SYSTEM_MD` を設定するとデフォルトプロンプトを書き出せる。
 
 import path from 'node:path';
 import fs from 'node:fs';

--- a/packages/core/src/prompts/mcp-prompts.ts
+++ b/packages/core/src/prompts/mcp-prompts.ts
@@ -2,7 +2,9 @@
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
- */
+*/
+
+// MCP サーバーから利用可能なプロンプト一覧を取得するヘルパー関数。
 
 import { Config } from '../config/config.js';
 import { DiscoveredMCPPrompt } from '../tools/mcp-client.js';

--- a/packages/core/src/prompts/prompt-registry.ts
+++ b/packages/core/src/prompts/prompt-registry.ts
@@ -2,7 +2,9 @@
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
- */
+*/
+
+// MCP サーバーから取得したプロンプトを登録・参照する簡易レジストリ。
 
 import { DiscoveredMCPPrompt } from '../tools/mcp-client.js';
 

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -2,7 +2,10 @@
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
- */
+*/
+
+// ユーザーの長期記憶ファイルに項目を追記するツール。
+// CLI からの `/remember` 的な指示に応じて GEMINI.md に情報を保存する。
 
 import { BaseTool, Icon, ToolResult } from './tools.js';
 import { FunctionDeclaration, Type } from '@google/genai';

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -2,7 +2,11 @@
  * @license
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
- */
+*/
+
+// GEMINI.md を階層的に探索し、ユーザーのメモリ内容を結合する読み込みシステム。
+// MemoryTool と連携しており、グローバル設定やプロジェクト単位のファイルから
+// インポートを解析しながらコンテキストを生成する。
 
 import * as fs from 'fs/promises';
 import * as fsSync from 'fs';


### PR DESCRIPTION
## Summary
- add Japanese comments on key core modules

## Testing
- `npm run preflight` *(fails: cannot find package 'glob')*

------
https://chatgpt.com/codex/tasks/task_e_688828a3d0308323bedc8ab99ee6f887